### PR TITLE
feat: add MVM and MVM-MVI basic compose files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "mvm_mvi/Sedimark-Toolbox"]
+	path = mvm_mvi/Sedimark-Toolbox
+	url = git@github.com:Sedimark/Sedimark-Toolbox.git

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
-# platform
-Manifests and compose files to deploy the Sedimark platform
+# Sedimark platform deployment
+
+This repository contains manifests and instructions to deploy the Sedimark platform.
+
+## Local deployment with Docker 
+
+### Prerequisites
+
+Ensure you have Docker compose installed, version 2.23.0 or higher. You can check this by running:
+
+```bash
+docker compose version
+```
+
+If you don't have Docker compose installed, you can install it by following the instructions in the [Docker documentation](https://docs.docker.com/compose/install/).
+
+### Marketplace only
+
+If you wish to deploy only the marketplace and its necessary dependencies, you can do so by running the following command:
+
+```bash
+cd mvm
+docker compose --env-file .env up -d
+```
+
+Feel free to modify the `.env` file to suit your needs. The default configuration should work for most users.
+
+⚠️ This Docker compose contains a catalogue instance: it is present only for testing purposes. You can point to any other remote catalogue by setting the `MARKETPLACE_CATALOGUE_URL` environment variable in the `.env` file. The catalogue instance is not meant to be used in production.
+
+### Full deployment
+
+If you wish to deploy the full Sedimark platform, including the marketplace and the Sedimark toolbox, you can do so by running the following command:
+
+```bash
+cd mvm_mvi
+docker compose up -d
+```
+

--- a/mvm/.env
+++ b/mvm/.env
@@ -1,0 +1,5 @@
+# Marketplace config
+export MARKETPLACE_BATCH_SIZE=10
+export MARKETPLACE_CATALOGUE_URL=http://catalogue:3030
+# Catalogue config
+export CATALOGUE_ADMIN_PASSWORD=admin

--- a/mvm/docker-compose.yaml
+++ b/mvm/docker-compose.yaml
@@ -5,13 +5,14 @@ services:
     ports:
       - "3000:3000"
     networks:
-      - sedimark
+      - sedimark_shared
     environment:
       - NODE_ENV=production
       - BATCH_SIZE=10
       - CATALOGUE_URL=http://catalogue:3030
       - RECOMMENDER_URL=http://recommender:8000
       - DLT_BOOTH_URL=http://dlt-booth:8085
+      - BROKER_URL=http://api-gateway:8080
 
   catalogue:
     image: stain/jena-fuseki:latest
@@ -21,7 +22,7 @@ services:
     volumes:
       - catalogue_data:/fuseki
     networks:
-      - sedimark
+      - sedimark_shared
     environment:
       - ADMIN_PASSWORD=admin
 
@@ -33,7 +34,7 @@ services:
     volumes:
       - recommender_data:/data/db
     networks:
-      - sedimark
+      - sedimark_shared
     environment:
       - CATALOGUE_URL=http://catalogue:3030
 
@@ -42,5 +43,5 @@ volumes:
   recommender_data:
 
 networks:
-  sedimark:
+  sedimark_shared:
     driver: bridge

--- a/mvm/docker-compose.yaml
+++ b/mvm/docker-compose.yaml
@@ -1,0 +1,46 @@
+services:
+  marketplace:
+    image: ghcr.io/sedimark/marketplace-frontend:development
+    container_name: marketplace-frontend
+    ports:
+      - "3000:3000"
+    networks:
+      - sedimark
+    environment:
+      - NODE_ENV=production
+      - BATCH_SIZE=10
+      - CATALOGUE_URL=http://catalogue:3030
+      - RECOMMENDER_URL=http://recommender:8000
+      - DLT_BOOTH_URL=http://dlt-booth:8085
+
+  catalogue:
+    image: stain/jena-fuseki:latest
+    container_name: catalogue
+    ports:
+      - "3030:3030"
+    volumes:
+      - catalogue_data:/fuseki
+    networks:
+      - sedimark
+    environment:
+      - ADMIN_PASSWORD=admin
+
+  recommender:
+    image: ghcr.io/sedimark/recommender:dev
+    container_name: recommender
+    ports:
+      - "8000:8000"
+    volumes:
+      - recommender_data:/data/db
+    networks:
+      - sedimark
+    environment:
+      - CATALOGUE_URL=http://catalogue:3030
+
+volumes:
+  catalogue_data:
+  recommender_data:
+
+networks:
+  sedimark:
+    driver: bridge

--- a/mvm/docker-compose.yaml
+++ b/mvm/docker-compose.yaml
@@ -8,8 +8,8 @@ services:
       - sedimark_shared
     environment:
       - NODE_ENV=production
-      - BATCH_SIZE=10
-      - CATALOGUE_URL=http://catalogue:3030
+      - BATCH_SIZE=${MARKETPLACE_BATCH_SIZE}
+      - CATALOGUE_URL=${MARKETPLACE_CATALOGUE_URL}
       - RECOMMENDER_URL=http://recommender:8000
       - DLT_BOOTH_URL=http://dlt-booth:8085
       - BROKER_URL=http://api-gateway:8080
@@ -24,7 +24,7 @@ services:
     networks:
       - sedimark_shared
     environment:
-      - ADMIN_PASSWORD=admin
+      - ADMIN_PASSWORD=${CATALOGUE_ADMIN_PASSWORD}
 
   recommender:
     image: ghcr.io/sedimark/recommender:dev
@@ -36,7 +36,7 @@ services:
     networks:
       - sedimark_shared
     environment:
-      - CATALOGUE_URL=http://catalogue:3030
+      - CATALOGUE_URL=${MARKETPLACE_CATALOGUE_URL}
 
 volumes:
   catalogue_data:

--- a/mvm_mvi/docker-compose.yaml
+++ b/mvm_mvi/docker-compose.yaml
@@ -1,0 +1,12 @@
+include:
+  - path: ../mvm/docker-compose.yaml
+  - path:
+      - ./Sedimark-Toolbox/ngsild_broker_deployment/docker-compose.yml
+      - ./stellio-override.yaml
+    env_file: ./Sedimark-Toolbox/ngsild_broker_deployment/.env
+
+networks:
+  sedimark_shared:
+    driver: bridge
+  stellio:
+    driver: bridge

--- a/mvm_mvi/stellio-override.yaml
+++ b/mvm_mvi/stellio-override.yaml
@@ -1,0 +1,24 @@
+services:
+  kafka:
+    networks: !override
+      - stellio
+
+  postgres:
+    networks: !override
+      - stellio
+
+  api-gateway:
+    networks: !override
+      - sedimark_shared
+      - stellio
+
+  search-service:
+    networks: !override
+      - stellio
+
+  subscription-service:
+    networks: !override
+      - stellio
+
+networks:
+  shared_network: !reset null


### PR DESCRIPTION
## Description

Hi there! This PR implements docker compose files for:
- the MVM, i.e. just the marketplace without the toolbox. It contains a catalogue instance, but this should be removed before the end of the project, to be replaced by the Sedimark central catalogue. It misses the DLT booth, because the later doesn't provide a Docker image yet (only a Dockerfile so far, but image should come very soon).
- the MVM-MVI, i.e. the marketplace with the Sedimark toolbox: so far, it only includes the NGSI-LD broker from the toolbox. The reason behind this is that I would prefer validating the approach taken in this PR before going further.

The MVM-MVI compose file is built by including the MVM file and the broker compose file: it leverages network isolation by creating (so far) two networks:
- a *sedimark_shared* network, intended to host main components which need to communicate between them.
- a *stellio* network, to host dependencies of the broker.
This approach ensures that no conflict between resources can arise. For instance, the broker uses a postgres database, like many other components in Sedimark. Each of these database will dwell in the dependencies' networks, so we don't have to modify their config to avoid conflicts in the master docker compose.

Anyway, tell me what you think!

## How to test 

A simple `docker compose up -d` in either the `mvm` or `mvm_mvi` folder will pull all the images and start their containers. However, if you want to try the marketplace, you'll need a few things:
- populate the catalogue: for this, you can navigate to `http://localhost:3030` and then create a dataset named `catalogue`, then _add data_, and then upload a file with your catalogue data. You can generate such a file [using this script](https://github.com/Sedimark/catalogue/blob/main/mock_catalogue/create_catalogue.py). Or I can send it to you.
- optional: you can populate the NGSI-LD broker with a dummy asset description. For instance, you can run: 
```bash
curl --request POST \
  --url http://localhost:8080/ngsi-ld/v1/entities \
  --header 'Content-Type: application/json' \
  --header 'Link: <https://sedimark.github.io/broker/jsonld-contexts/sedimark-compound.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"' \
  --data '{
  "id": "urn:ngsi-ld:Asset:01",
  "type": "Asset",
  "title": {
    "type": "Property",
    "value": "Title for Asset 1"
  },
  "creator": {
    "type": "Relationship",
    "object": "urn:ngsi-ld:Participant:MyParticipantId"
  },
  "description": {
    "type": "Property",
    "value": "This is a description for the Asset 1, look at that, im quite fancy"
  },
  "publisher": {
    "type": "Relationship",
    "object": "urn:ngsi-ld:Participant:MyParticipantId"
  },
  "issued": {
    "type": "Property",
    "value": "2024-09-01T11:00:00.000Z"
  },
  "modified": {
    "type": "Property",
    "value": "2024-09-01T11:00:00.000Z"
  },
  "keyword": {
    "type": "Property",
    "value": ["Keyword1", "Keyword3"]
  },
  "license": {
    "type": "Property",
    "value": "https://creativecommons.org/licenses/by-nd/4.0/"
  },
  "spatial": {
    "type": "Property",
    "value": "https://sws.geonames.org/6299418/"
  },
  "startedAtTime": {
    "type": "Property",
    "value": "2024-01-01T01:00:00.000Z"
  },
  "endedAtTime": {
    "type": "Property",
    "value": "2024-12-31T23:59:59.000Z"
  },
  "version": {
    "type": "Property",
    "value": "v1.1"
  },
  "endpointURL": {
    "type": "Property",
    "value": "https://my.endpoint01/url"
  },
  "endpointDescription": {
    "type": "Property",
    "value": "this is what my endpoint do"
  },
  "image": {
    "type": "Property",
    "value": "https://image.com/my/image01"
  },
  "location": {
    "type": "GeoProperty",
    "value": {
      "type": "Point",
      "coordinates": [
        1.5,
        1.5
      ]
    }
  }
}'
```

The marketplace is exposed at `http://localhost:3000`.

## Possible improvements

- use an env file in the Docker compose to set some of the variables. Can be done here on request or in a follow up PR.