### PR TITLE
Add toolbox compose into platform deployment.

### DIFF
--- a/mvm_mvi/docker-compose.yaml
+++ b/mvm_mvi/docker-compose.yaml
@@ -4,9 +4,16 @@ include:
       - ./Sedimark-Toolbox/ngsild_broker_deployment/docker-compose.yml
       - ./stellio-override.yaml
     env_file: ./Sedimark-Toolbox/ngsild_broker_deployment/.env
+  - path:
+      - ./Sedimark-Toolbox/toolbox_deployment/docker-compose.yaml
+      - ./toolbox-override.yaml
+    env_file:
+      - ./Sedimark-Toolbox/toolbox_deployment/.env
 
 networks:
   sedimark_shared:
     driver: bridge
   stellio:
+    driver: bridge
+  toolbox:
     driver: bridge

--- a/mvm_mvi/toolbox-override.yaml
+++ b/mvm_mvi/toolbox-override.yaml
@@ -1,0 +1,36 @@
+services:
+  mlflow:
+    networks: !override
+      - toolbox
+
+  mlflow_postgres:
+    networks: !override
+      - toolbox
+
+  minio:
+    networks: !override
+      - toolbox
+
+  minio-init:
+    networks: !override
+      - toolbox
+
+  magic:
+    networks: !override
+      - sedimark_shared
+      - toolbox
+
+  mageapi:
+    networks: !override
+      - toolbox
+
+  orchestrator:
+    networks: !override
+      - toolbox
+
+  mlflowapi:
+    networks: !override
+      - toolbox
+
+networks:
+  shared_network: !reset null


### PR DESCRIPTION
I have added the toolbox docker compose inside the mvm_mvi docker-compose deployment, after some modifications were made on the Sedimark-Toolbox repository to accommodate the integration.

@xamcost If you can review this and if it is ok after the components are ready we can start easily test the platform.

To run and test the update you can do docker compose up -d, and it should be able to pull the images, if not I will add you as a contributor to all of the repositories.