### PR TITLE
feat: add profile server to MVM docker compose

### DIFF
--- a/mvm/.env.example
+++ b/mvm/.env.example
@@ -1,6 +1,8 @@
 # Marketplace config
 export MARKETPLACE_BATCH_SIZE=10
 export MARKETPLACE_CATALOGUE_URL=http://catalogue:3030
+# Profile server config
+export PROFILE_API_KEY=password
 # Catalogue config
 export CATALOGUE_ADMIN_PASSWORD=admin
 # DLT booth config

--- a/mvm/docker-compose.yaml
+++ b/mvm/docker-compose.yaml
@@ -19,6 +19,18 @@ services:
       - DLT_BOOTH_URL=http://dlt-booth:8085
       - BROKER_URL=http://api-gateway:8080
 
+  profile:
+    image: ghcr.io/sedimark/profile:latest
+    container_name: profile
+    ports:
+      - "3005:3005"
+    networks:
+      - sedimark_shared
+    environment:
+      - API_KEY=${PROFILE_API_KEY}
+    volumes:
+      - profile_server_data:/app/data
+
   catalogue:
     image: stain/jena-fuseki:latest
     container_name: catalogue
@@ -44,6 +56,7 @@ services:
       - CATALOGUE_URL=${MARKETPLACE_CATALOGUE_URL}
 
 volumes:
+  profile_server_data:
   catalogue_data:
   recommender_data:
 


### PR DESCRIPTION
## Description

Hi there! This small PR adds the profile server to the MVM docker compose, enabling users to expose their private data from a locally hosted private server.

## How to test

Example request can be found in [the profile repository README](https://github.com/Sedimark/profile), as well as a Bruno collection